### PR TITLE
Allow pets in DeathWatch Bunker

### DIFF
--- a/MMOCoreORB/bin/scripts/screenplays/dungeon/death_watch_bunker/deathWatchBunker.lua
+++ b/MMOCoreORB/bin/scripts/screenplays/dungeon/death_watch_bunker/deathWatchBunker.lua
@@ -213,12 +213,6 @@ function DeathWatchBunkerScreenPlay:spawnObjects()
 	local spawnedSceneObject = LuaSceneObject(nil)
 	local spawnedPointer
 
-	-- To disallow entry by PETS
-	local pActiveArea = spawnActiveArea("endor", "object/active_area.iff", -4664.4, 4.4, 4318.9, -90, 5996315)
-	if pActiveArea ~= nil then
-		createObserver(ENTEREDAREA, "DeathWatchBunkerScreenPlay", "notifyPetEnteredDeny", pActiveArea)
-	end
-
 	-- Door Access Terminal Outside
 	spawnedPointer = spawnSceneObject("endor", "object/tangible/dungeon/death_watch_bunker/door_control_terminal.iff", -18.016,-12,-8.55806, 5996315, 1, 0, 0, 0)
 	spawnedSceneObject:_setObject(spawnedPointer)


### PR DESCRIPTION
With the enhanced creature handler experience, pets should be allowed in all dungeons.