### PR TITLE
Allow crafting repair bonuses at Novice level

### DIFF
--- a/MMOCoreORB/bin/scripts/object/tangible/crafting/station/armor_repair.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/crafting/station/armor_repair.lua
@@ -47,7 +47,7 @@ object_tangible_crafting_station_armor_repair = object_tangible_crafting_station
 
 	canRepairType = 256, -- Armor
 
-	boostSkill = "crafting_armorsmith_master",
+	boostSkill = "crafting_armorsmith_novice",
 	boostSkillMod = "armor_repair",
 
 	stationType = 1,

--- a/MMOCoreORB/bin/scripts/object/tangible/crafting/station/clothing_repair.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/crafting/station/clothing_repair.lua
@@ -47,7 +47,7 @@ object_tangible_crafting_station_clothing_repair = object_tangible_crafting_stat
 
 	canRepairType = 16777216, -- Clothing
 
-	boostSkill = "crafting_tailor_master",
+	boostSkill = "crafting_tailor_novice",
 	boostSkillMod = "clothing_repair",
 
 	stationType = 1,

--- a/MMOCoreORB/bin/scripts/object/tangible/crafting/station/weapon_repair.lua
+++ b/MMOCoreORB/bin/scripts/object/tangible/crafting/station/weapon_repair.lua
@@ -47,7 +47,7 @@ object_tangible_crafting_station_weapon_repair = object_tangible_crafting_statio
 
 	canRepairType = 131072, -- Weapon
 
-	boostSkill = "crafting_weaponsmith_master",
+	boostSkill = "crafting_weaponsmith_novice",
 	boostSkillMod = "weapon_repair",
 
 	stationType = 7,


### PR DESCRIPTION
This could be changed in the future, but with lower server population, it is difficult to find someone to repair items.    The current code requires Master in each profession.