### PR TITLE
Change shuttle boarding range to 90 meters

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/creature/commands/BoardShuttleCommand.h
+++ b/MMOCoreORB/src/server/zone/objects/creature/commands/BoardShuttleCommand.h
@@ -67,7 +67,7 @@ public:
 			return GENERALERROR;
 		}
 
-		if (!shuttle->isInRange(creature, 25.f)) {
+		if (!shuttle->isInRange(creature, 90.f)) {
 			creature->sendSystemMessage("@player_structure:boarding_too_far"); //You are too far from the shuttle to board.
 			return GENERALERROR;
 		}


### PR DESCRIPTION
Back in Publish 4, you could board a starport shuttle from anywhere in the starport as the range was 128 meters.   90 meters will allow boarding from the ticket terminal in all starports including Theed.   This should make starports a little more usable.    Pub 4 also had a check to only allow the long distance inside, but I don't think that is necessary.