### PR TITLE
Foraging tapes now grant bonus and shellfish fix

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/minigames/ForageManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/minigames/ForageManagerImplementation.cpp
@@ -186,8 +186,8 @@ void ForageManagerImplementation::finishForaging(CreatureObject* player, int for
 	}
 
 	//Determine if player finds an item.
-	if (chance > 100) //There could possibly be +foraging skill tapes.
-		chance = 100;
+	if (chance > 125) //There could possibly be +foraging skill tapes.
+		chance = 125;
 
 	if (System::random(80) > chance) {
 		if (forageType == ForageManager::SHELLFISH)
@@ -267,7 +267,7 @@ bool ForageManagerImplementation::forageGiveItems(CreatureObject* player, int fo
 
 	if (forageType == ForageManager::SHELLFISH){
 		bool mullosks = false;
-		if (System::random(100) > 500) {
+		if (System::random(100) > 50) {
 			resName = "seafood_mollusk";
 			mullosks = true;
 		}


### PR DESCRIPTION
The code was not allowing for +25 foraging tapes to a master ranger and it was never bringing up mollusks because of the incorrect value (500 vs. 50).