### PR TITLE
Fixed damage multiplier on Legshot3

### DIFF
--- a/MMOCoreORB/bin/scripts/commands/legShot3.lua
+++ b/MMOCoreORB/bin/scripts/commands/legShot3.lua
@@ -44,7 +44,7 @@
 LegShot3Command = {
         name = "legshot3",
 
-	damageMultiplier = 2.0,
+	damageMultiplier = 3.0,
 	speedMultiplier = 2.0,
 	healthCostMultiplier = 0.5,
 	actionCostMultiplier = 2.0,


### PR DESCRIPTION
This was a bug going back to live where legShot3 did no more damage than legShot2.    This brings the multiplier in line with other professions.