### PR TITLE
Increase power of HK Liquid to make it useful alternative

### DIFF
--- a/MMOCoreORB/bin/scripts/loot/items/hk_liquid.lua
+++ b/MMOCoreORB/bin/scripts/loot/items/hk_liquid.lua
@@ -6,7 +6,7 @@ hk_liquid = {
 	customObjectName = "HK Liquid",
 	directObjectTemplate = "object/tangible/component/chemistry/liquid_delivery_suspension.iff",
 	craftingValues = {
-		{"power",20,30,0},
+		{"power",55,80,0},
 		{"charges",5,15,0},
 		{"useCount",15,30,0},
 	},


### PR DESCRIPTION
A perfect legendary HK Liquid was previously worse than a quality crafted component.