### PR TITLE
 Adjust chance of babies spawning in screenplays/POI's to be equal to…

### DIFF
--- a/MMOCoreORB/src/server/zone/objects/creature/ai/AiAgentImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/creature/ai/AiAgentImplementation.cpp
@@ -1262,7 +1262,7 @@ void AiAgentImplementation::respawn(Zone* zone, int level) {
 	CreatureManager* creatureManager = zone->getCreatureManager();
 
 	if (npcTemplate != NULL && creatureManager != NULL && isCreature()) {
-		int chance = 2000;
+		int chance = 1000;
 		int babiesSpawned = 0;
 
 		ManagedReference<SceneObject*> home = homeObject.get();


### PR DESCRIPTION
… destroy missions

This increases the chance of a creature with 0.25 taming chance to 2.5% up from 1.25%.