### PR TITLE
saber1hflurry2 set to 4.5 damage multiplier

### DIFF
--- a/MMOCoreORB/bin/scripts/commands/saber1hFlurry2.lua
+++ b/MMOCoreORB/bin/scripts/commands/saber1hFlurry2.lua
@@ -44,7 +44,7 @@
 Saber1hFlurry2Command = {
         name = "saber1hflurry2",
 
-	damageMultiplier = 4.0,
+	damageMultiplier = 4.5,
 	speedMultiplier = 4.0,
 	healthCostMultiplier = 0,
 	actionCostMultiplier = 0,


### PR DESCRIPTION
I confirmed from the scrapbook that all the saber specials granted at master LS had a 4.50 damage multiplier here:
http://www.swgemu.com/archive/scrapbookv51/data/20070127180650/